### PR TITLE
Откорректирован запрос выборки последней позиции для ClickHouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+.vscode/
+
 # Project-specific files
 log.txt
 

--- a/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
@@ -40,7 +40,7 @@ namespace OneSTools.EventLog.Exporter.Core.ClickHouse
             await CreateConnectionAsync(cancellationToken);
 
             var commandText =
-                $"SELECT TOP 1 FileName, EndPosition, LgfEndPosition, Id FROM {TableName} ORDER BY Id DESC";
+                $"SELECT TOP 1 FileName, EndPosition, LgfEndPosition, Id FROM {TableName} ORDER BY DateTime DESC, EndPosition DESC";
 
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = commandText;

--- a/OneSTools.EventLog/EventLogReader.cs
+++ b/OneSTools.EventLog/EventLogReader.cs
@@ -157,7 +157,7 @@ namespace OneSTools.EventLog
 
             _lgpFilesWatcher = new FileSystemWatcher(_settings.LogFolder, "*.lgp")
             {
-                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite
+                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size
             };
             _lgpFilesWatcher.Changed += LgpFilesWatcher_Event;
             _lgpFilesWatcher.Created += LgpFilesWatcher_Event;


### PR DESCRIPTION
Более точное (на мой взгляд) определение последней позиции файла лога для кликхаус-экспортера
+ Запрос в кликхаус теперь отрабатывает моментально за счет попадания индекса
Связанные задачи: #21 #46 возможно поможет и для #49 

Попутно:
* служебный каталог ".vscode" добавлен в гитигнор
* вотчер за файлом лога отслеживает и изменение размера файла