### PR TITLE
Отслеживание изменений файлов лога по таймеру, а не по событиям ФС

### DIFF
--- a/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
@@ -92,16 +92,18 @@ namespace OneSTools.EventLog.Exporter.Core.ClickHouse
                 item.Session
             }).AsEnumerable();
 
-            try
-            {
-                await copy.WriteToServerAsync(data, cancellationToken);
+            while(true){
+                try
+                {
+                    await copy.WriteToServerAsync(data, cancellationToken);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, $"Failed to write data to {_databaseName}." + System.Environment.NewLine + ex.Message);
+                    await Task.Delay(1000);
+                }
             }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, $"Failed to write data to {_databaseName}");
-                throw;
-            }
-
             _logger?.LogDebug($"{entities.Count} items were being written to {_databaseName}");
         }
 

--- a/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
+++ b/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
@@ -28,8 +28,7 @@ namespace OneSTools.EventLog.Exporter.Manager
             _path = Path.Combine(_folder, "1CV8Clst.lst");
             if (!File.Exists(_path))
                 throw new Exception("Couldn't find LST \"1CV8Clst.lst\" file");
-
-            _infoBases = ReadInfoBases();
+            
             InitializeWatcher();
         }
 
@@ -94,9 +93,9 @@ namespace OneSTools.EventLog.Exporter.Manager
             return items;
         }
 
-        private void ReadInfoBasesAndRaiseEvents()
+        private async void ReadInfoBasesAndRaiseEvents()
         {
-            var newInfoBases = ReadInfoBases();
+            var newInfoBases = await ReadInfoBases();
 
             var added = newInfoBases.Except(_infoBases);
             foreach (var (key, (item1, item2)) in added)
@@ -109,8 +108,9 @@ namespace OneSTools.EventLog.Exporter.Manager
             _infoBases = newInfoBases;
         }
 
-        private void InitializeWatcher()
+        private async void InitializeWatcher()
         {
+            _infoBases = await ReadInfoBases();
             _clstWatcher = new FileSystemWatcher(_folder, "1CV8Clst.lst")
             {
                 NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite

--- a/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
+++ b/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
@@ -46,8 +46,10 @@ namespace OneSTools.EventLog.Exporter.Manager
         private Dictionary<string, (string Name, string DataBaseName)> ReadInfoBases()
         {
             var items = new Dictionary<string, (string, string)>();
-
-            var fileData = File.ReadAllText(_path);
+            
+            using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite); 
+            using var stream = new StreamReader(fs); 
+            var fileData = stream.ReadToEnd();
             var parsedData = BracketsParser.ParseBlock(fileData);
 
             var infoBasesNode = parsedData[2];

--- a/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
+++ b/OneSTools.EventLog.Exporter.Manager/ClstWatcher.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using OneSTools.BracketsFile;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace OneSTools.EventLog.Exporter.Manager
 {
@@ -44,14 +44,13 @@ namespace OneSTools.EventLog.Exporter.Manager
         public event InfoBaseAddedHandler InfoBasesAdded;
         public event InfoBaseDeletedHandler InfoBasesDeleted;
 
-        private Dictionary<string, (string Name, string DataBaseName)> ReadInfoBases()
+        private async Task<Dictionary<string, (string Name, string DataBaseName)>> ReadInfoBases()
         {
             var items = new Dictionary<string, (string, string)>();
 
             String fileData = null;
-            int tryCount = 10;
-            const int sleepTimeout = 1000;
-            while (fileData == null && tryCount > 0)
+            int tryCount = 10;            
+            while (fileData == null)
             {
                 try
                 {
@@ -65,7 +64,7 @@ namespace OneSTools.EventLog.Exporter.Manager
                     tryCount--;
                     if (tryCount == 0)
                         throw new Exception("Ошибка чтения файла списка баз", e);
-                    Thread.Sleep(sleepTimeout);
+                    await Task.Delay(1000);
                 }                
             }
             

--- a/OneSTools.EventLog/EventLogReader.cs
+++ b/OneSTools.EventLog/EventLogReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Timers;
+using Timers = System.Timers;
 
 namespace OneSTools.EventLog
 {
@@ -16,7 +16,7 @@ namespace OneSTools.EventLog
         private bool _disposedValue;
         private LgfReader _lgfReader;
         private ManualResetEvent _lgpChangedCreated;        
-        private System.Timers.Timer _Timer;
+        private Timers.Timer _Timer;
         private LgpReader _lgpReader;
 
         public EventLogReader(EventLogReaderSettings settings)
@@ -156,15 +156,14 @@ namespace OneSTools.EventLog
         {
             _lgpChangedCreated = new ManualResetEvent(false);
 
-            _Timer = new System.Timers.Timer(_settings.ReadingTimeout);
+            _Timer = new Timers.Timer(_settings.ReadingTimeout);
             _Timer.Elapsed += OnTimedEvent;
             _Timer.AutoReset = true;
             _Timer.Enabled = true;
         }
 
-        private void OnTimedEvent(Object source, ElapsedEventArgs e)
+        private void OnTimedEvent(Object source, Timers.ElapsedEventArgs e)
         {
-            //Console.WriteLine("Срабатывание таймера: {0:HH:mm:ss.fff}", e.SignalTime);
             _lgpChangedCreated.Set();
         }
 

--- a/OneSTools.EventLog/EventLogReader.cs
+++ b/OneSTools.EventLog/EventLogReader.cs
@@ -115,12 +115,12 @@ namespace OneSTools.EventLog
 
         private bool SetNextLgpReader()
         {
-            var currentReaderLastWriteDateTime = DateTime.MinValue;
+            string currentFileName = "19000101000000";
 
             if (_lgpReader != null)
-                currentReaderLastWriteDateTime = new FileInfo(_lgpReader.LgpPath).LastWriteTime;
+                currentFileName = new FileInfo(_lgpReader.LgpPath).Name;
 
-            var filesDateTime = new List<(string, DateTime)>();
+            var filesDateTime = new List<(string, string)>();
 
             var files = Directory.GetFiles(_settings.LogFolder, "*.lgp");
 
@@ -128,16 +128,15 @@ namespace OneSTools.EventLog
                 if (_lgpReader != null)
                 {
                     if (_lgpReader.LgpPath != file)
-                        filesDateTime.Add((file, new FileInfo(file).LastWriteTime));
+                        filesDateTime.Add((file, new FileInfo(file).Name));
                 }
                 else
                 {
-                    filesDateTime.Add((file, new FileInfo(file).LastWriteTime));
+                    filesDateTime.Add((file, new FileInfo(file).Name));
                 }
-
-            var orderedFiles = filesDateTime.OrderBy(c => c.Item2).ToList();
-
-            var (item1, _) = orderedFiles.FirstOrDefault(c => c.Item2 > currentReaderLastWriteDateTime);
+            
+            filesDateTime.Sort((x, y) => string.Compare(y.Item2, x.Item2));
+            var (item1, _) = filesDateTime.FirstOrDefault(c => string.Compare(c.Item2, currentFileName) > 0);
 
             if (string.IsNullOrEmpty(item1))
             {


### PR DESCRIPTION
В связи с тем, что отслеживание изменений файлов логов через изменение атрибутов файлов ненадежное https://github.com/akpaevj/OneSTools.EventLog/issues/51
переделал на отслеживание по таймеру. Количество секунд таймера берется из настройки ReadingTimeout