### PR TITLE
Исправление создания дубликатов при начале дня

### DIFF
--- a/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
@@ -35,12 +35,16 @@ namespace OneSTools.EventLog.Exporter.Core.ClickHouse
             Init();
         }
 
-        public async Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default)
+        public async Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default, string filename = "")
         {
             await CreateConnectionAsync(cancellationToken);
 
             var commandText =
                 $"SELECT TOP 1 FileName, EndPosition, LgfEndPosition, Id FROM {TableName} ORDER BY DateTime DESC, EndPosition DESC";
+
+            if (filename != "") {
+                commandText = $"SELECT TOP 1 FileName, EndPosition, LgfEndPosition, Id FROM {_tableName} WHERE FileName = '{filename}' ORDER BY EndPosition DESC";
+            }
 
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = commandText;

--- a/OneSTools.EventLog.Exporter.Core/ElasticSearch/ElasticSearchStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/ElasticSearch/ElasticSearchStorage.cs
@@ -53,7 +53,7 @@ namespace OneSTools.EventLog.Exporter.Core.ElasticSearch
             CheckSettings();
         }
 
-        public async Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default)
+        public async Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default, string filename = "")
         {
             if (_client is null)
                 await ConnectAsync(cancellationToken);

--- a/OneSTools.EventLog.Exporter.Core/EventLogExporter.cs
+++ b/OneSTools.EventLog.Exporter.Core/EventLogExporter.cs
@@ -39,6 +39,7 @@ namespace OneSTools.EventLog.Exporter.Core
         public EventLogExporter(EventLogExporterSettings settings, IEventLogStorage storage,
             ILogger<EventLogExporter> logger = null)
         {
+            // Constructor - EventLogExportersManager
             _logger = logger;
             _storage = storage;
 
@@ -57,6 +58,7 @@ namespace OneSTools.EventLog.Exporter.Core
         public EventLogExporter(ILogger<EventLogExporter> logger, IConfiguration configuration,
             IEventLogStorage storage)
         {
+            // Constructor - EventLogExporter
             _logger = logger;
             _storage = storage;
 
@@ -137,6 +139,12 @@ namespace OneSTools.EventLog.Exporter.Core
                     if (item != null)
                     {
                         if (!string.IsNullOrEmpty(_eventLogReader.LgpFileName) && _currentLgpFile != _eventLogReader.LgpFileName) {
+                            if (_counterSkip > 0)
+                            {
+                                _logger?.LogInformation($"Reader skipped {_counterSkip} items. {_eventLogReader.LgpFileName}");
+                                _counterSkip = 0;
+                            }
+
                             _logger?.LogInformation($"Reader changed to {_eventLogReader.LgpFileName}");
 
                             _currentLgpFile = _eventLogReader.LgpFileName;
@@ -152,13 +160,12 @@ namespace OneSTools.EventLog.Exporter.Core
                         }
 
                         //await SendAsync(_batchBlock, item, cancellationToken);
-                        if (item.EndPosition > _currentPos.EndPosition) {
+                        if (item.EndPosition > _currentPos.EndPosition)
+                        {
                             await SendAsync(_batchBlock, item, cancellationToken);
-                            if (_counterSkip > 0) {
-                                _logger?.LogInformation($"Reader skipped {_counterSkip} items. {_eventLogReader.LgpFileName}");
-                                _counterSkip = 0;
-                            }
-                        } else {
+                        }
+                        else
+                        {
                             _counterSkip++;
                             _eventLogReader.BackId();
                         }

--- a/OneSTools.EventLog.Exporter.Core/EventLogExporter.cs
+++ b/OneSTools.EventLog.Exporter.Core/EventLogExporter.cs
@@ -140,6 +140,8 @@ namespace OneSTools.EventLog.Exporter.Core
                             _logger?.LogInformation($"Reader changed to {_eventLogReader.LgpFileName}");
 
                             _currentLgpFile = _eventLogReader.LgpFileName;
+                            // Need fix batch
+                            forceSending = true;
 
                             var newPos = await _storage.ReadEventLogPositionAsync(cancellationToken, _eventLogReader.LgpFileName);
                             if (newPos != null) {
@@ -158,6 +160,7 @@ namespace OneSTools.EventLog.Exporter.Core
                             }
                         } else {
                             _counterSkip++;
+                            _eventLogReader.BackId();
                         }
                     }
                     else if (!settings.LiveMode)

--- a/OneSTools.EventLog.Exporter.Core/IEventLogStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/IEventLogStorage.cs
@@ -7,7 +7,7 @@ namespace OneSTools.EventLog.Exporter.Core
 {
     public interface IEventLogStorage : IDisposable
     {
-        Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default);
+        Task<EventLogPosition> ReadEventLogPositionAsync(CancellationToken cancellationToken = default, string filename = "");
         Task WriteEventLogDataAsync(List<EventLogItem> entities, CancellationToken cancellationToken = default);
     }
 }

--- a/OneSTools.EventLog/EventLogReader.cs
+++ b/OneSTools.EventLog/EventLogReader.cs
@@ -46,6 +46,11 @@ namespace OneSTools.EventLog
             GC.SuppressFinalize(this);
         }
 
+        public void BackId()
+        {
+            _settings.ItemId--;
+        }
+
         /// <summary>
         ///     The behaviour of the method depends on the mode of the reader. In the "live" mode it'll be waiting for an appearing
         ///     of the new event item, otherwise It'll just return null


### PR DESCRIPTION
Fix #46 

Первая версия
Логика такая: при начале чтения нового файла лога из базы вытягивается EndPosition и если EndPosition записи меньше этого значения - то запись пропускается.