### PR TITLE
Added 99 attempts to send data to clickhouse

### DIFF
--- a/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
+++ b/OneSTools.EventLog.Exporter.Core/ClickHouse/ClickHouseStorage.cs
@@ -92,14 +92,23 @@ namespace OneSTools.EventLog.Exporter.Core.ClickHouse
                 item.Session
             }).AsEnumerable();
 
-            try
+            for (int number_try = 0; number_try < 100; number_try++)
             {
-                await copy.WriteToServerAsync(data, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, $"Failed to write data to {_databaseName}");
-                throw;
+                try
+                {
+                    await copy.WriteToServerAsync(data, cancellationToken);
+                    break;
+                }
+                catch (Exception ex)
+                {
+
+                    await Task.Delay(1000);
+                    if (number_try == 99) 
+                        {
+                        _logger?.LogError(ex, $"Failed to write data to {_databaseName}");
+                        throw;
+                    }
+                }
             }
 
             _logger?.LogDebug($"{entities.Count} items were being written to {_databaseName}");


### PR DESCRIPTION
В моменты когда на сервере кликхауса недостаточно свободной оперативной памяти из-за обрабатываемых в данный момент запросов, возможна ошибка отправки. Этот цикл решил мою проблему полностью для 25 баз, в совокупности 25 млрд. строк. существуют на 12 ГБ ОЗУ.